### PR TITLE
fix: add missing include demo file

### DIFF
--- a/src/demo/github-commit-signature.md
+++ b/src/demo/github-commit-signature.md
@@ -1,0 +1,21 @@
+# GitHub Commit Signature
+
+这个文件用于演示 `@include` 语法。
+
+你可以在提交页面看到签名状态：
+
+- **Verified**: 提交经过签名验证
+- **Partially verified**: 仅部分信息完成验证
+- **Unverified**: 未通过签名验证
+
+## 小贴士
+
+1. 使用 GPG 或 SSH key 给提交签名。
+2. 在 GitHub 设置中上传公钥。
+3. 开启本地 Git 的 `commit.gpgsign`。
+4. 重新提交后检查签名状态。
+5. 对关键分支启用受保护策略。
+6. 配置 CI 检查提交来源。
+7. 定期轮换密钥并妥善保管。
+
+以上内容仅作为文档演示示例。


### PR DESCRIPTION
### Motivation
- 修复 `src/demo/markdown.md` 中的 `@include` 引用因缺失文件 `src/demo/github-commit-signature.md` 导致构建时出现警告的问题。

### Description
- 添加 `src/demo/github-commit-signature.md`，提供被 `@include ...{11-17}` 引用的示例内容以便正确渲染。

### Testing
- 在修复前后均运行了 `pnpm docs:build`，修复前构建成功但出现 `[@mdit/plugin-include]: ... github-commit-signature.md not found` 警告，修复后构建成功且该警告消失，渲染页数从 `51` 增至 `52`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ee7f29aa8832abf5f9b89240a6129)